### PR TITLE
Refactor add player message

### DIFF
--- a/tabletennis/static/tabletennis/css/landingpage.css
+++ b/tabletennis/static/tabletennis/css/landingpage.css
@@ -1,4 +1,7 @@
-#name-error-label {
-    opacity: 0;
-    transition: opacity 0.3s linear;
+.message-container {
+    position: relative;
+}
+
+.message-container span {
+    position: absolute;
 }

--- a/tabletennis/static/tabletennis/js/utils.js
+++ b/tabletennis/static/tabletennis/js/utils.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function showMessage(container, msg, cssClass) {
+    container = $(container);
+    // Hide and remove all previous messages.
+    $(container).children().each(function() {
+        $(this).fadeOut(150, function() { $(this).remove() });
+    });
+    // Create and fade in new message element.
+    let element = `<span><small class="${cssClass} form-text">${msg}</small></span>`
+    $(element).hide().appendTo(container).fadeIn(150);
+}

--- a/tabletennis/templates/tabletennis/includes/addplayer_modal.html
+++ b/tabletennis/templates/tabletennis/includes/addplayer_modal.html
@@ -13,7 +13,10 @@
       <div class="modal-body">
 
         <input id="name-input" name="name" type="text" class="form-control" aria-describedby="playername" autocomplete="off">
-        <small id="name-message-label" class="text-danger form-text">Name is already taken.</small>
+        <div id="name-input-message-container" class="message-container">
+          <span><small class="text-muted">Choose a player name...</small></span>
+        </div>
+        <br>
 
       </div>
       <div class="modal-footer">

--- a/tabletennis/templates/tabletennis/landingpage.html
+++ b/tabletennis/templates/tabletennis/landingpage.html
@@ -9,6 +9,7 @@
 <script>
     var addPlayerUrl = "{% url 'add_player_view' %}";
 </script>
+<script src="{% static 'tabletennis/js/utils.js' %}"></script>
 <script src="{% static 'tabletennis/js/landingpage.js' %}"></script>
 {% endblock %}
 

--- a/tabletennis/views.py
+++ b/tabletennis/views.py
@@ -12,21 +12,19 @@ class LandingPageView(View):
 
 class AddPlayerView(View):
     def get(self, request):
-
         add_player_form = AddPlayerForm(request.GET)
-        messageType = 'SUCCESS' if add_player_form.is_valid() else 'ERROR'
-        content = add_player_form.errors.get('name', ['NOMESSAGE'])[0]
+        messageType = 'HIDDEN' if add_player_form.is_valid() else 'ERROR'
+        content = add_player_form.errors.get('name', [''])[0]
 
         return JsonResponse({
             'name': request.GET.get('name', ''),
             'message': {
-                'messageType': messageType, 
+                'messageType': messageType,
                 'content': content
             }
         })
 
     def post(self, request):
-
         add_player_form = AddPlayerForm(request.POST)
         if add_player_form.is_valid():
             # Only true, if input length < 20, not empty and name not already taken (case insensitive).
@@ -36,12 +34,12 @@ class AddPlayerView(View):
             content = f'Player with name {add_player_form.cleaned_data.get("name")} was added.'
         else:
             messageType = 'ERROR'
-            content = add_player_form.errors.get('name', ['NOMESSAGE'])[0]
+            content = add_player_form.errors.get('name', [''])[0]
 
         return JsonResponse({
             'name': request.POST.get('name', ''),
             'message': {
-                'messageType': messageType, 
+                'messageType': messageType,
                 'content': content
             }
         })


### PR DESCRIPTION
Refactoring of add player message. To provide a consistent fading behavior (color, opacity) independent of previous state (visible->visible, visible->invisible, green->red, etc...), we need to move away from using one single message HTML element, because changes in text cannot be animated. We now use a message container, which upon displaying a message first fades out all previous messages (and subsequently deletes them) and at the same time creates a new message element in the container and fades that in. Using the concept of absolute and relative positioning (we need to look at that anyway for the autocomplete input), we place alle messages on the same spot. Therefore fading out the old message element and at the same time fading in the new message element creates the illusion of blending opacity, color and text.